### PR TITLE
fix #5

### DIFF
--- a/litdata.sml
+++ b/litdata.sml
@@ -6,15 +6,15 @@
  *)
 structure LiteralData = struct
 
-    type integer = Int32.int
+    type integer = Int.int
 
-    val fromInt = Int32.fromInt
-    val toInt = Int32.toInt
+    val fromInt = Int.fromInt
+    val toInt = Int.toInt
 
-    val fromString = Int32.fromString
-    val toString = Int32.toString
+    val fromString = Int.fromString
+    val toString = Int.toString
 
-    val compare = Int32.compare
+    val compare = Int.compare
 
-    val toLarge = Int32.toLarge
+    val toLarge = Int.toLarge
 end


### PR DESCRIPTION
fix issue #5 where `make` after a fresh clone causes overflow

tested with MacOS 64-bit

**before this change:**

```
/usr/local/smlnj/bin/.run/run.amd64-darwin: Fatal error -- Uncaught exception Overflow with 0
 raised at <file mlpolyr.lex.sml>

make: *** [compiler] Error 1
```

**after this change:** builds successfully and the compiler seems to work


> There is a similar commit for fixing this same
issue on another branch: adf9f8060758294d3163e5691efc28ebc9a82878. That commit also updates load.sml